### PR TITLE
Add support for /block/:hash/header

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -375,6 +375,25 @@ paths:
                     type: number
                   previousblockhash:
                     type: string
+  /block/{hash}/header:
+    get:
+      summary: Returns the hex-encoded block header.
+      operationId: getBlockHeader
+      tags:
+        - block
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        default:
+          description: Block header
+          content:
+            application/json:
+              schema:
+                type: string
   /block/{hash}/status:
     get:
       summary: Returns the block status.


### PR DESCRIPTION
This PR adds support for the [/block/:hash/header](https://github.com/Blockstream/esplora/blob/master/API.md#get-blockhashheader) endpoint. Currently, the header must be parsed from the raw block data that's returned from `/block/:hash/raw`. This endpoint offers a much lighter alternative for fetching block headers.